### PR TITLE
remove async-trait

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -57,11 +57,9 @@ jobs:
     env:
       RUSTFLAGS: --cfg tokio_unstable
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build with tokio and tracing
-        uses: actions-rs/cargo@v1
-        with:
-          command: build  
-          args: --all --features "runtime-tokio anyhow tracing" --no-default-features
+        run: cargo build --all --features "runtime-tokio anyhow tracing" --no-default-features
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - stable minus 2 releases
+          # - stable minus 2 releases
           - beta
         feature:
           - runtime-tokio,anyhow

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ struct MyActor;
 
 impl Actor for MyActor {}
 
-#[async_trait::async_trait]
 impl Handler<ToUppercase> for MyActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: ToUppercase) -> String {
         msg.0.to_uppercase()

--- a/examples/caller.rs
+++ b/examples/caller.rs
@@ -16,7 +16,6 @@ struct CountActor {
 impl Actor for CountActor {}
 
 /// Handler for `Ping` message
-#[async_trait::async_trait]
 impl Handler<Ping> for CountActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Ping) -> usize {
         self.count += msg.0;
@@ -25,7 +24,6 @@ impl Handler<Ping> for CountActor {
 }
 
 /// Handler for `Ping` message
-#[async_trait::async_trait]
 impl Handler<Pow> for CountActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: Pow) {}
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -6,7 +6,6 @@ struct Die;
 
 struct MyActor;
 
-#[async_trait::async_trait]
 impl Actor for MyActor {
     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
         // Send the Die message 3 seconds later
@@ -15,7 +14,6 @@ impl Actor for MyActor {
     }
 }
 
-#[async_trait::async_trait]
 impl Handler<Die> for MyActor {
     async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Die) {
         // Stop the actor without error

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -13,7 +13,6 @@ struct MyActor {
 impl Actor for MyActor {}
 
 /// Handler for `Ping` message
-#[async_trait::async_trait]
 impl Handler<Ping> for MyActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Ping) -> usize {
         self.count += msg.0;

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -29,7 +29,6 @@ impl SubscriberParent {
     }
 }
 
-#[async_trait::async_trait]
 impl Actor for SubscriberParent {
     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
         println!("Subscriber Parent Started");
@@ -41,7 +40,6 @@ impl Actor for SubscriberParent {
 #[message]
 struct InitializeChildSubscribers;
 
-#[async_trait::async_trait]
 impl Handler<InitializeChildSubscribers> for SubscriberParent {
     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: InitializeChildSubscribers) {
         let message_producer_addr = self.message_producer.clone();
@@ -65,7 +63,6 @@ impl Handler<InitializeChildSubscribers> for SubscriberParent {
 #[message]
 struct ClearChildSubscribers;
 
-#[async_trait::async_trait]
 impl Handler<ClearChildSubscribers> for SubscriberParent {
     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: ClearChildSubscribers) {
         self.children_subscribers = Vec::new();
@@ -88,7 +85,6 @@ impl Subscriber {
     }
 }
 
-#[async_trait::async_trait]
 impl Actor for Subscriber {
     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
         // Send subscription request message to the Message Producer
@@ -101,7 +97,6 @@ impl Actor for Subscriber {
     }
 }
 
-#[async_trait::async_trait]
 impl Handler<RandomMessage> for Subscriber {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: RandomMessage) {
         // We just print out the random id, along with the actor's unique id
@@ -126,7 +121,6 @@ impl MessageProducer {
     }
 }
 
-#[async_trait::async_trait]
 impl Actor for MessageProducer {
     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
         // Send broadcast message to self every 2 seconds
@@ -149,7 +143,6 @@ struct Broadcast;
 #[derive(Clone)]
 struct RandomMessage(i32);
 
-#[async_trait::async_trait]
 impl Handler<Broadcast> for MessageProducer {
     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: Broadcast) {
         // Generate random number and broadcast that message to all subscribers
@@ -165,7 +158,6 @@ impl Handler<Broadcast> for MessageProducer {
     }
 }
 
-#[async_trait::async_trait]
 impl Handler<SubscribeToProducer> for MessageProducer {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: SubscribeToProducer) {
         println!("Recieved Subscription Request");

--- a/examples/supervisor_clear_interval.rs
+++ b/examples/supervisor_clear_interval.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 #[derive(Debug)]
 pub struct PingTimer;
 
-#[async_trait::async_trait]
 impl Actor for PingTimer {
     async fn started(&mut self, ctx: &mut Context<Self>) -> hannibal::Result<()> {
         println!("PingTimer :: started()");
@@ -22,7 +21,6 @@ impl Actor for PingTimer {
 #[derive(Clone)]
 struct Ping;
 
-#[async_trait::async_trait]
 impl Handler<Ping> for PingTimer {
     async fn handle(&mut self, _: &mut Context<Self>, _msg: Ping) {
         println!("PingTimer :: Ping");
@@ -31,7 +29,6 @@ impl Handler<Ping> for PingTimer {
 #[message]
 struct Restart;
 
-#[async_trait::async_trait]
 impl Handler<Restart> for PingTimer {
     async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Restart) {
         println!("PingTimer :: received restart");
@@ -42,7 +39,6 @@ impl Handler<Restart> for PingTimer {
 #[message]
 struct Shutdown;
 
-#[async_trait::async_trait]
 impl Handler<Shutdown> for PingTimer {
     async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Shutdown) {
         println!("PingTimer :: received Shutdown");
@@ -53,7 +49,6 @@ impl Handler<Shutdown> for PingTimer {
 #[message]
 struct Panic;
 
-#[async_trait::async_trait]
 impl Handler<Panic> for PingTimer {
     async fn handle(&mut self, _: &mut Context<Self>, _msg: Panic) {
         println!("PingTimer :: received Panic");

--- a/examples/supervisor_clear_send_later.rs
+++ b/examples/supervisor_clear_send_later.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 #[derive(Debug, Default)]
 pub struct PingLater;
 
-#[async_trait::async_trait]
 impl Actor for PingLater {
     async fn started(&mut self, ctx: &mut Context<Self>) -> hannibal::Result<()> {
         ctx.send_later(Ping("after halt"), Duration::from_millis(1_500));
@@ -21,7 +20,6 @@ impl Actor for PingLater {
 #[derive(Debug)]
 struct Ping(&'static str);
 
-#[async_trait::async_trait]
 impl Handler<Ping> for PingLater {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Ping) {
         println!("PingLater:: handle {:?}", msg);
@@ -30,7 +28,6 @@ impl Handler<Ping> for PingLater {
 #[message]
 struct Halt;
 
-#[async_trait::async_trait]
 impl Handler<Halt> for PingLater {
     async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Halt) {
         println!("PingLater:: received Halt");

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -16,7 +16,11 @@ where
     Self: std::marker::Sized,
 {
     /// Method is called for every message received by this Actor.
-    async fn handle(&mut self, ctx: &mut Context<Self>, msg: T) -> T::Result;
+    fn handle(
+        &mut self,
+        ctx: &mut Context<Self>,
+        msg: T,
+    ) -> impl futures::Future<Output = T::Result> + Send;
 }
 
 /// Describes how to handle messages of a specific type.
@@ -26,16 +30,22 @@ where
 #[allow(unused_variables)]
 pub trait StreamHandler<T: 'static>: Actor {
     /// Method is called for every message received by this Actor.
-    async fn handle(&mut self, ctx: &mut Context<Self>, msg: T);
+    fn handle(
+        &mut self,
+        ctx: &mut Context<Self>,
+        msg: T,
+    ) -> impl futures::Future<Output = ()> + Send;
 
     /// Method is called when stream get polled first time.
-    async fn started(&mut self, ctx: &mut Context<Self>) {}
+    fn started(&mut self, ctx: &mut Context<Self>) -> impl futures::Future<Output = ()> + Send {
+        async {}
+    }
 
     /// Method is called when stream finishes.
     ///
     /// By default this method stops actor execution.
-    async fn finished(&mut self, ctx: &mut Context<Self>) {
-        ctx.stop(None);
+    fn finished(&mut self, ctx: &mut Context<Self>) -> impl futures::Future<Output = ()> + Send {
+        async { ctx.stop(None) }
     }
 }
 
@@ -53,21 +63,26 @@ pub trait Actor: Sized + Send + 'static {
     const NAME: &'static str = "hannibal::Actor";
 
     /// Called when the actor is first started.
-    async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
-        Ok(())
+    fn started(
+        &mut self,
+        ctx: &mut Context<Self>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        async { Ok(()) }
     }
 
     /// Called after an actor is stopped.
-    async fn stopped(&mut self, ctx: &mut Context<Self>) {}
+    fn stopped(&mut self, ctx: &mut Context<Self>) -> impl std::future::Future<Output = ()> + Send {
+        async {}
+    }
 
     /// Construct and start a new actor, returning its address.
     ///
     /// This is constructs a new actor using the [`Default`] trait, and invokes its [`start`](`Actor::start`) method.
-    async fn start_default() -> Result<Addr<Self>>
+    fn start_default() -> impl std::future::Future<Output = Result<Addr<Self>>> + Send
     where
         Self: Default,
     {
-        Ok(Self::default().start().await?)
+        async { Self::default().start().await }
     }
 
     /// Start a new actor, returning its address.
@@ -101,8 +116,8 @@ pub trait Actor: Sized + Send + 'static {
     ///     Ok(())
     /// }
     /// ```
-    async fn start(self) -> Result<Addr<Self>> {
-        LifeCycle::new().start_actor(self).await
+    fn start(self) -> impl std::future::Future<Output = Result<Addr<Self>>> + Send {
+        async { LifeCycle::new().start_actor(self).await }
     }
 
     fn name(&self) -> Cow<'static, str> {

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -11,7 +11,6 @@ pub trait Message: 'static + Send {
 /// Describes how to handle messages of a specific type.
 /// Implementing Handler is a general way to handle incoming messages.
 /// The type `T` is a message which can be handled by the actor.
-#[async_trait::async_trait]
 pub trait Handler<T: Message>: Actor
 where
     Self: std::marker::Sized,
@@ -24,7 +23,6 @@ where
 /// Implementing Handler is a general way to handle incoming streams.
 /// The type T is a stream message which can be handled by the actor.
 /// Stream messages do not need to implement the [`Message`] trait.
-#[async_trait::async_trait]
 #[allow(unused_variables)]
 pub trait StreamHandler<T: 'static>: Actor {
     /// Method is called for every message received by this Actor.
@@ -50,7 +48,6 @@ pub trait StreamHandler<T: 'static>: Actor {
 /// The requester can wait for a response.
 /// By [`Addr`] referring to the actors, the actors must provide an [`Handler<T>`] implementation for this message.
 /// All messages are statically typed.
-#[async_trait::async_trait]
 #[allow(unused_variables)]
 pub trait Actor: Sized + Send + 'static {
     const NAME: &'static str = "hannibal::Actor";
@@ -87,7 +84,6 @@ pub trait Actor: Sized + Send + 'static {
     /// #[message(result = "i32")]
     /// struct MyMsg(i32);
     ///
-    /// #[async_trait::async_trait]
     /// impl Handler<MyMsg> for MyActor {
     ///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: MyMsg) -> i32 {
     ///         msg.0 * msg.0

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -48,7 +48,6 @@ impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
 /// #[derive(Default)]
 /// struct MyActor(String);
 ///
-/// #[async_trait::async_trait]
 /// impl Actor for MyActor {
 ///     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()>  {
 ///         ctx.subscribe::<MyMsg>().await;
@@ -56,14 +55,12 @@ impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
 ///     }
 /// }
 ///
-/// #[async_trait::async_trait]
 /// impl Handler<MyMsg> for MyActor {
 ///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: MyMsg) {
 ///         self.0 += msg.0;
 ///     }
 /// }
 ///
-/// #[async_trait::async_trait]
 /// impl Handler<GetValue> for MyActor {
 ///     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: GetValue) -> String {
 ///         self.0.clone()
@@ -103,21 +100,18 @@ impl<T: Message<Result = ()>> Actor for Broker<T> {}
 
 impl<T: Message<Result = ()>> Service for Broker<T> {}
 
-#[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Subscribe<T>> for Broker<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Subscribe<T>) {
         self.subscribes.insert(msg.id, Box::new(msg.sender));
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Unsubscribe> for Broker<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Unsubscribe) {
         self.subscribes.remove(&msg.id);
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Message<Result = ()> + Clone> Handler<Publish<T>> for Broker<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Publish<T>) {
         for sender in self.subscribes.values_mut() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -123,7 +123,6 @@ impl<A> Context<A> {
     /// #[derive(Default)]
     /// struct MyActor(i32);
     ///
-    /// #[async_trait::async_trait]
     /// impl StreamHandler<i32> for MyActor {
     ///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: i32) {
     ///         self.0 += msg;
@@ -138,14 +137,12 @@ impl<A> Context<A> {
     ///     }
     /// }
     ///
-    /// #[async_trait::async_trait]
     /// impl Handler<GetSum> for MyActor {
     ///     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: GetSum) -> i32 {
     ///         self.0
     ///     }
     /// }
     ///
-    /// #[async_trait::async_trait]
     /// impl Actor for MyActor {
     ///     async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
     ///         let values = (0..100).collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 //! impl Actor for MyActor {}
 //!
-//! #[async_trait::async_trait]
 //! impl Handler<ToUppercase> for MyActor {
 //!     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: ToUppercase) -> String {
 //!         msg.0.to_uppercase()

--- a/src/service.rs
+++ b/src/service.rs
@@ -46,22 +46,24 @@ use crate::{error::Result, lifecycle::LifeCycle, Actor, Addr};
 /// }
 /// ```
 pub trait Service: Actor + Default {
-    async fn from_registry() -> Result<Addr<Self>> {
-        static REGISTRY: OnceCell<
-            Mutex<HashMap<TypeId, Box<dyn Any + Send>, BuildHasherDefault<FnvHasher>>>,
-        > = OnceCell::new();
-        let registry = REGISTRY.get_or_init(Default::default);
-        let mut registry = registry.lock().await;
+    fn from_registry() -> impl std::future::Future<Output = Result<Addr<Self>>> + Send {
+        async {
+            static REGISTRY: OnceCell<
+                Mutex<HashMap<TypeId, Box<dyn Any + Send>, BuildHasherDefault<FnvHasher>>>,
+            > = OnceCell::new();
+            let registry = REGISTRY.get_or_init(Default::default);
+            let mut registry = registry.lock().await;
 
-        match registry.get_mut(&TypeId::of::<Self>()) {
-            Some(addr) => Ok(addr.downcast_ref::<Addr<Self>>().unwrap().clone()),
-            None => {
-                let life_cycle = LifeCycle::new();
+            match registry.get_mut(&TypeId::of::<Self>()) {
+                Some(addr) => Ok(addr.downcast_ref::<Addr<Self>>().unwrap().clone()),
+                None => {
+                    let life_cycle = LifeCycle::new();
 
-                registry.insert(TypeId::of::<Self>(), Box::new(life_cycle.address()));
-                drop(registry);
+                    registry.insert(TypeId::of::<Self>(), Box::new(life_cycle.address()));
+                    drop(registry);
 
-                life_cycle.start_actor(Self::default()).await
+                    life_cycle.start_actor(Self::default()).await
+                }
             }
         }
     }
@@ -76,23 +78,25 @@ thread_local! {
 /// The service is a thread local actor.
 /// You can use `Actor::from_registry` to get the address `Addr<A>` of the service.
 pub trait LocalService: Actor + Default {
-    async fn from_registry() -> Result<Addr<Self>> {
-        let res = LOCAL_REGISTRY.with(|registry| {
-            registry
-                .borrow_mut()
-                .get_mut(&TypeId::of::<Self>())
-                .map(|addr| addr.downcast_ref::<Addr<Self>>().unwrap().clone())
-        });
-        match res {
-            Some(addr) => Ok(addr),
-            None => {
-                let addr = LifeCycle::new().start_actor(Self::default()).await?;
-                LOCAL_REGISTRY.with(|registry| {
-                    registry
-                        .borrow_mut()
-                        .insert(TypeId::of::<Self>(), Box::new(addr.clone()));
-                });
-                Ok(addr)
+    fn from_registry() -> impl std::future::Future<Output = Result<Addr<Self>>> + Send {
+        async {
+            let res = LOCAL_REGISTRY.with(|registry| {
+                registry
+                    .borrow_mut()
+                    .get_mut(&TypeId::of::<Self>())
+                    .map(|addr| addr.downcast_ref::<Addr<Self>>().unwrap().clone())
+            });
+            match res {
+                Some(addr) => Ok(addr),
+                None => {
+                    let addr = LifeCycle::new().start_actor(Self::default()).await?;
+                    LOCAL_REGISTRY.with(|registry| {
+                        registry
+                            .borrow_mut()
+                            .insert(TypeId::of::<Self>(), Box::new(addr.clone()));
+                    });
+                    Ok(addr)
+                }
             }
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -30,7 +30,6 @@ use crate::{error::Result, lifecycle::LifeCycle, Actor, Addr};
 ///
 /// impl Service for MyService {}
 ///
-/// #[async_trait::async_trait]
 /// impl Handler<AddMsg> for MyService {
 ///     async fn handle(&mut self, ctx: &mut Context<Self>, msg: AddMsg) -> i32 {
 ///         self.0 += msg.0;
@@ -46,7 +45,6 @@ use crate::{error::Result, lifecycle::LifeCycle, Actor, Addr};
 ///     Ok(())
 /// }
 /// ```
-#[async_trait::async_trait]
 pub trait Service: Actor + Default {
     async fn from_registry() -> Result<Addr<Self>> {
         static REGISTRY: OnceCell<
@@ -77,7 +75,6 @@ thread_local! {
 ///
 /// The service is a thread local actor.
 /// You can use `Actor::from_registry` to get the address `Addr<A>` of the service.
-#[async_trait::async_trait]
 pub trait LocalService: Actor + Default {
     async fn from_registry() -> Result<Addr<Self>> {
         let res = LOCAL_REGISTRY.with(|registry| {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -28,21 +28,18 @@ impl Supervisor {
     ///
     /// impl Actor for MyActor {}
     ///
-    /// #[async_trait::async_trait]
     /// impl Handler<Add> for MyActor {
     ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Add) {
     ///         self.0 += 1;
     ///     }
     /// }
     ///
-    /// #[async_trait::async_trait]
     /// impl Handler<Get> for MyActor {
     ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Get) -> i32 {
     ///         self.0
     ///     }
     /// }
     ///
-    /// #[async_trait::async_trait]
     /// impl Handler<Die> for MyActor {
     ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Die) {
     ///         ctx.stop(None);

--- a/tests/caller.rs
+++ b/tests/caller.rs
@@ -12,7 +12,6 @@ struct CountActor {
 }
 impl Actor for CountActor {}
 
-#[async_trait::async_trait]
 impl Handler<Count> for CountActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, Count(diff): Count) -> usize {
         self.count += diff;
@@ -20,7 +19,6 @@ impl Handler<Count> for CountActor {
     }
 }
 
-#[async_trait::async_trait]
 impl Handler<Ping> for CountActor {
     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: Ping) {}
 }

--- a/tests/stop.rs
+++ b/tests/stop.rs
@@ -2,7 +2,6 @@
 struct MyActor;
 
 /// Declare actor and its context
-#[async_trait::async_trait]
 impl hannibal::Actor for MyActor {
     async fn stopped(&mut self, _ctx: &mut hannibal::Context<Self>) {
         println!("stopped");


### PR DESCRIPTION
this replaces the use of `#[async_trait]` with [RPITIT](https://github.com/rust-lang/rfcs/blob/master/text/3425-return-position-impl-trait-in-traits.md), which will not be stable until xmas 2023