### PR TITLE
feat: handle stop reason

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,10 +18,8 @@ jobs:
           # - stable minus 2 releases
           - beta
         feature:
-          - runtime-tokio,anyhow
-          - runtime-async-std,anyhow
-          - runtime-tokio,eyre
-          - runtime-async-std,eyre
+          - runtime-tokio
+          - runtime-async-std
           - default
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +29,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt
 
-      - name: check 
+      - name: check
         run: cargo check --no-default-features --features ${{ matrix.feature }}
 
       - name: check (benches)
@@ -50,7 +48,7 @@ jobs:
       - name: package
         run: cargo package
 
-  
+
   build_experimental:
     name: "Build with experimental flags"
     runs-on: ubuntu-latest
@@ -61,5 +59,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
       - name: Build with tokio and tracing
-        run: cargo build --all --features "runtime-tokio anyhow tracing" --no-default-features
-
+        run: cargo build --all --features "runtime-tokio tracing" --no-default-features

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,29 +22,28 @@ jobs:
           rm convco
 
 
-  semver:
-    name: cargo-semver-checks
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - default
-          - runtime-tokio
-          - runtime-async-std
-          # - runtime-tokio, tracing
-          # - runtime-async-std, tracing
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2.6
-        env:
-          RUSTFLAGS: --cfg tokio_unstable
-        with:
-          feature-group: "only-explicit-features"
-          features: ${{ matrix.features}}
+  # semver:
+  #   name: cargo-semver-checks
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       features:
+  #         - default
+  #         - runtime-tokio
+  #         - runtime-async-std
+  #         # - runtime-tokio, tracing
+  #         # - runtime-async-std, tracing
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: check semver
+  #       uses: obi1kenobi/cargo-semver-checks-action@v2.6
+  #       env:
+  #         RUSTFLAGS: --cfg tokio_unstable
+  #       with:
+  #         feature-group: "only-explicit-features"
+  #         features: ${{ matrix.features}}
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,14 +29,10 @@ jobs:
       matrix:
         features:
           - default
-          - anyhow, runtime-tokio
-          - anyhow, runtime-async-std
-          - eyre, runtime-tokio
-          - eyre, runtime-async-std
-          # - anyhow, runtime-tokio, tracing
-          # - anyhow, runtime-async-std, tracing
-          # - eyre, runtime-tokio, tracing
-          # - eyre, runtime-async-std, tracing
+          - runtime-tokio
+          - runtime-async-std
+          # - runtime-tokio, tracing
+          # - runtime-async-std, tracing
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ fnv = "1.0"
 slab = "0.4"
 dyn-clone = "1"
 async-lock = "3"
+thiserror = "1"
 
 [dependencies.async-std]
 version = "1.12"
@@ -37,14 +38,6 @@ optional = true
 path = "hannibal-derive"
 version = "0.10"
 
-[dependencies.anyhow]
-version = "1.0"
-optional = true
-
-[dependencies.eyre]
-version = "0.6"
-optional = true
-
 [dev-dependencies]
 color-backtrace = "0.6.0"
 ctor = "0.2.6"
@@ -59,4 +52,4 @@ members = ["hannibal-derive"]
 runtime-tokio = ["tokio/rt-multi-thread", "tokio/macros", "tokio/time"]
 runtime-async-std = ["async-std"]
 tracing = ["tokio/tracing"]
-default = ["runtime-async-std", "anyhow"]
+default = ["runtime-async-std"]

--- a/examples/stopping.rs
+++ b/examples/stopping.rs
@@ -1,0 +1,51 @@
+use hannibal::*;
+use std::time::Duration;
+
+#[message]
+struct Die;
+
+struct MyActor(&'static str);
+
+impl Actor for MyActor {
+    async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
+        // Send the Die message 3 seconds later
+        ctx.send_later(Die, Duration::from_secs(3));
+        Ok(())
+    }
+
+    async fn stopping(&mut self, _ctx: &mut Context<Self>, reason: StopReason) {
+        if let Some(reason) = reason {
+            println!("✋ stopping {} with reason: {}", self.0, reason);
+        } else {
+            println!("✋ stopping {} without reason", self.0);
+        }
+    }
+    async fn stopped(&mut self, _ctx: &mut Context<Self>) {
+        println!("🛑 actually {} stopped", self.0);
+    }
+}
+
+impl Handler<Die> for MyActor {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Die) {
+        ctx.stop(reason("timeout"));
+    }
+}
+
+fn reason(msg: &str) -> StopReason {
+    Some(Box::<dyn std::error::Error + Send + Sync>::from(msg))
+}
+
+#[hannibal::main]
+async fn main() -> Result<()> {
+    let mut a1 = MyActor("1").start().await?;
+    let mut a2 = MyActor("2").start().await?;
+    // Exit the program after 3 seconds
+    let a3 = MyActor("3").start().await?;
+
+    a1.stop(reason("halt and catch fire")).unwrap();
+    a2.stop(None).unwrap();
+
+    futures::join!(a1.wait_for_stop(), a2.wait_for_stop(), a3.wait_for_stop(),);
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -1,12 +1,8 @@
 test:
-    cargo test --no-default-features --features runtime-tokio,anyhow
-    cargo test --no-default-features --features runtime-async-std,anyhow
-    cargo test --no-default-features --features runtime-tokio,eyre
-    cargo test --no-default-features --features runtime-async-std,eyre
+    cargo test --no-default-features --features runtime-tokio
+    cargo test --no-default-features --features runtime-async-std
     cargo test --no-default-features --features runtime-tokio,tracing
 semver-checks:
     # cargo semver-checks --only-explicit-features --features default
-    cargo semver-checks --only-explicit-features --features runtime-tokio --features anyhow
-    cargo semver-checks --only-explicit-features --features runtime-async-std --features anyhow
-    cargo semver-checks --only-explicit-features --features runtime-tokio --features eyre
-    cargo semver-checks --only-explicit-features --features runtime-async-std --features eyre
+    cargo semver-checks --only-explicit-features --features runtime-tokio
+    cargo semver-checks --only-explicit-features --features runtime-async-std

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{error::Result, lifecycle::LifeCycle, Addr, Context};
+use crate::{addr::StopReason, error::Result, lifecycle::LifeCycle, Addr, Context};
 
 pub trait Message: 'static + Send {
     /// The return value type of the message
@@ -68,6 +68,15 @@ pub trait Actor: Sized + Send + 'static {
         ctx: &mut Context<Self>,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
         async { Ok(()) }
+    }
+
+    /// Called with stop reason before an actor is stopped.
+    fn stopping(
+        &mut self,
+        ctx: &mut Context<Self>,
+        reason: StopReason,
+    ) -> impl std::future::Future<Output = ()> + Send {
+        async {}
     }
 
     /// Called after an actor is stopped.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,6 +1,6 @@
 use crate::{
-    channel::ChanTx, context::RunningFuture, error::anyhow, weak_addr::WeakAddr, Actor, ActorId,
-    Context, Error, Handler, Message, Result,
+    channel::ChanTx, context::RunningFuture, error::Error, weak_addr::WeakAddr, Actor, ActorId,
+    Context, Handler, Message, Result,
 };
 use futures::{channel::oneshot, Future};
 use std::{
@@ -161,7 +161,7 @@ impl<A: Actor> Addr<A> {
                     Ok(response.await?)
                 }) as Pin<Box<dyn Future<Output = Result<T::Result>>>>
             } else {
-                Box::pin(ready(Err(anyhow!("Actor Dropped"))))
+                Box::pin(ready(Error::AlreadyStopped.into()))
             }
         };
 
@@ -188,7 +188,7 @@ impl<A: Actor> Addr<A> {
                     Box::pin(Handler::handle(&mut *actor, ctx, msg))
                 }))
             } else {
-                Err(anyhow!("Actor Dropped"))
+                Error::AlreadyStopped.into()
             }
         };
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -17,13 +17,15 @@ pub use self::{caller::Caller, sender::Sender};
 
 type ExecFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
+pub(crate) type OptionalError = Option<Box<dyn std::error::Error + Send + 'static>>;
+
 pub(crate) type ExecFn<A> =
     Box<dyn for<'a> FnOnce(&'a mut A, &'a mut Context<A>) -> ExecFuture<'a> + Send + 'static>;
 
 pub(crate) enum ActorEvent<A> {
     Exec(ExecFn<A>),
-    Stop(Option<Error>),
-    StopSupervisor(Option<Error>),
+    Stop(OptionalError),
+    StopSupervisor(OptionalError),
     RemoveStream(usize),
 }
 
@@ -95,7 +97,7 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Stop the actor.
-    pub fn stop(&mut self, err: Option<Error>) -> Result<()> {
+    pub fn stop(&mut self, err: OptionalError) -> Result<()> {
         self.tx.send(ActorEvent::Stop(err))?;
         Ok(())
     }
@@ -103,7 +105,7 @@ impl<A: Actor> Addr<A> {
     /// Stop the supervisor.
     ///
     /// this is ignored by normal actors
-    pub fn stop_supervisor(&mut self, err: Option<Error>) -> Result<()> {
+    pub fn stop_supervisor(&mut self, err: OptionalError) -> Result<()> {
         self.tx.send(ActorEvent::StopSupervisor(err))?;
         Ok(())
     }

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -17,15 +17,15 @@ pub use self::{caller::Caller, sender::Sender};
 
 type ExecFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
-pub(crate) type OptionalError = Option<Box<dyn std::error::Error + Send + 'static>>;
+pub type StopReason = Option<Box<dyn std::error::Error + Send + 'static>>;
 
 pub(crate) type ExecFn<A> =
     Box<dyn for<'a> FnOnce(&'a mut A, &'a mut Context<A>) -> ExecFuture<'a> + Send + 'static>;
 
 pub(crate) enum ActorEvent<A> {
     Exec(ExecFn<A>),
-    Stop(OptionalError),
-    StopSupervisor(OptionalError),
+    Stop(StopReason),
+    StopSupervisor(StopReason),
     RemoveStream(usize),
 }
 
@@ -97,7 +97,7 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Stop the actor.
-    pub fn stop(&mut self, err: OptionalError) -> Result<()> {
+    pub fn stop(&mut self, err: StopReason) -> Result<()> {
         self.tx.send(ActorEvent::Stop(err))?;
         Ok(())
     }
@@ -105,7 +105,7 @@ impl<A: Actor> Addr<A> {
     /// Stop the supervisor.
     ///
     /// this is ignored by normal actors
-    pub fn stop_supervisor(&mut self, err: OptionalError) -> Result<()> {
+    pub fn stop_supervisor(&mut self, err: StopReason) -> Result<()> {
         self.tx.send(ActorEvent::StopSupervisor(err))?;
         Ok(())
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    addr::{ActorEvent, OptionalError},
+    addr::{ActorEvent, StopReason},
     broker::{Subscribe, Unsubscribe},
     channel::{ChannelWrapper, WeakChanTx},
     runtime::{sleep, spawn},
@@ -66,7 +66,7 @@ where
     }
 
     /// Stop the actor.
-    pub fn stop(&self, err: OptionalError) {
+    pub fn stop(&self, err: StopReason) {
         if let Some(tx) = self.weak_tx.upgrade() {
             tx.send(ActorEvent::Stop(err)).ok();
         }
@@ -75,7 +75,7 @@ where
     /// Stop the supervisor.
     ///
     /// this is ignored by normal actors
-    pub fn stop_supervisor(&self, err: OptionalError) {
+    pub fn stop_supervisor(&self, err: StopReason) {
         if let Some(tx) = self.weak_tx.upgrade() {
             tx.send(ActorEvent::StopSupervisor(err)).ok();
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,9 @@
 use crate::{
-    addr::ActorEvent,
+    addr::{ActorEvent, OptionalError},
     broker::{Subscribe, Unsubscribe},
     channel::{ChannelWrapper, WeakChanTx},
     runtime::{sleep, spawn},
-    Actor, ActorId, Addr, Broker, Error, Handler, Message, Result, Service, StreamHandler,
+    Actor, ActorId, Addr, Broker, Handler, Message, Result, Service, StreamHandler,
 };
 use futures::{
     future::{AbortHandle, Abortable},
@@ -66,7 +66,7 @@ where
     }
 
     /// Stop the actor.
-    pub fn stop(&self, err: Option<Error>) {
+    pub fn stop(&self, err: OptionalError) {
         if let Some(tx) = self.weak_tx.upgrade() {
             tx.send(ActorEvent::Stop(err)).ok();
         }
@@ -75,7 +75,7 @@ where
     /// Stop the supervisor.
     ///
     /// this is ignored by normal actors
-    pub fn stop_supervisor(&self, err: Option<Error>) {
+    pub fn stop_supervisor(&self, err: OptionalError) {
         if let Some(tx) = self.weak_tx.upgrade() {
             tx.send(ActorEvent::StopSupervisor(err)).ok();
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Actor already stopped")]
+    AlreadyStopped,
+
+    #[error("Failed to get lock on actor")]
+    WriteError,
+
+    #[error("Failed to spawn")]
+    SpawnError,
+
+    #[error("Failed to send message")]
+    AsyncSendError(#[from] futures::channel::mpsc::SendError),
+
+    #[error("Call got canceled")]
+    Canceled(#[from] futures::channel::oneshot::Canceled),
+}
+
+impl<T> Into<Result<T>> for Error {
+    fn into(self) -> Result<T> {
+        Err(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub type ActorId = u64;
 
 pub use actor::{Actor, Handler, Message, StreamHandler};
 
-pub use addr::{caller::Caller, sender::Sender, Addr};
+pub use addr::{caller::Caller, sender::Sender, Addr, StopReason};
 pub use weak_addr::WeakAddr;
 
 pub use broker::Broker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 
 mod actor;
 mod addr;
+mod error;
 mod weak_addr;
 
 mod broker;
@@ -66,27 +67,7 @@ mod runtime;
 mod service;
 mod supervisor;
 
-#[cfg(all(feature = "anyhow", feature = "eyre"))]
-compile_error!(
-    r#"
-    features `hannibal/anyhow` and `hannibal/eyre` are mutually exclusive.
-    If you are trying to disable anyhow set `default-features = false`.
-"#
-);
-
-#[cfg(feature = "anyhow")]
-pub use anyhow as error;
-
-#[cfg(feature = "eyre")]
-pub use eyre as error;
-
-#[cfg_attr(feature = "eyre", doc = "Alias of [`eyre::Result`]")]
-#[cfg_attr(not(feature = "eyre"), doc = "Alias of [`anyhow::Result`]")]
-pub type Result<T> = error::Result<T>;
-
-#[cfg_attr(feature = "eyre", doc = "Alias of [`eyre::Error`]")]
-#[cfg_attr(not(feature = "eyre"), doc = "Alias of [`anyhow::Error`]")]
-pub type Error = error::Error;
+pub use error::{Error, Result};
 
 pub type ActorId = u64;
 

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -72,10 +72,10 @@ where
                 }
             }
 
-            actor.stopped(&mut ctx).await;
-
             ctx.abort_streams();
             ctx.abort_intervals();
+
+            actor.stopped(&mut ctx).await;
 
             tx_exit.send(()).ok();
         };
@@ -136,9 +136,10 @@ where
                     }
                 }
 
-                actor.stopped(&mut ctx).await;
                 ctx.abort_streams();
                 ctx.abort_intervals();
+
+                actor.stopped(&mut ctx).await;
 
                 actor = f();
                 actor.started(&mut ctx).await.ok();

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -62,7 +62,10 @@ where
             while let Some(event) = rx.recv().await {
                 match event {
                     ActorEvent::Exec(f) => f(&mut actor, &mut ctx).await,
-                    ActorEvent::Stop(_err) => break,
+                    ActorEvent::Stop(reason) => {
+                        actor.stopping(&mut ctx, reason).await;
+                        break;
+                    }
                     ActorEvent::StopSupervisor(_err) => {}
                     ActorEvent::RemoveStream(id) => {
                         if ctx.streams.contains(id) {
@@ -125,7 +128,10 @@ where
                 'event_loop: loop {
                     match rx.recv().await {
                         None => break 'restart_loop,
-                        Some(ActorEvent::Stop(_err)) => break 'event_loop,
+                        Some(ActorEvent::Stop(reason)) => {
+                            actor.stopping(&mut ctx, reason).await;
+                            break 'event_loop;
+                        }
                         Some(ActorEvent::StopSupervisor(_err)) => break 'restart_loop,
                         Some(ActorEvent::Exec(f)) => f(&mut actor, &mut ctx).await,
                         Some(ActorEvent::RemoveStream(id)) => {

--- a/src/weak_addr.rs
+++ b/src/weak_addr.rs
@@ -1,6 +1,6 @@
 use crate::{
-    channel::WeakChanTx, context::RunningFuture, error::bail, Actor, ActorId, Addr, Handler,
-    Message, Result,
+    channel::WeakChanTx, context::RunningFuture, Actor, ActorId, Addr, Error, Handler, Message,
+    Result,
 };
 use std::hash::{Hash, Hasher};
 
@@ -55,7 +55,7 @@ impl<A> WeakAddr<A> {
         if let Some(addr) = self.upgrade() {
             addr.send(msg)
         } else {
-            bail!("cannot upgrade");
+            Error::AlreadyStopped.into()
         }
     }
 }


### PR DESCRIPTION
so far the error passed to `Addr::stop(...)` was not used. Here add a new method `Actor::stopping()` that receives this error as a stop reason.