### PR TITLE
refactor: rename message type parameter to `M`

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -10,8 +10,8 @@ pub trait Message: 'static + Send {
 
 /// Describes how to handle messages of a specific type.
 /// Implementing Handler is a general way to handle incoming messages.
-/// The type `T` is a message which can be handled by the actor.
-pub trait Handler<T: Message>: Actor
+/// The type `M` is a message which can be handled by the actor.
+pub trait Handler<M: Message>: Actor
 where
     Self: std::marker::Sized,
 {
@@ -19,21 +19,21 @@ where
     fn handle(
         &mut self,
         ctx: &mut Context<Self>,
-        msg: T,
-    ) -> impl futures::Future<Output = T::Result> + Send;
+        msg: M,
+    ) -> impl futures::Future<Output = M::Result> + Send;
 }
 
 /// Describes how to handle messages of a specific type.
 /// Implementing Handler is a general way to handle incoming streams.
-/// The type T is a stream message which can be handled by the actor.
+/// The type `M` is a stream message which can be handled by the actor.
 /// Stream messages do not need to implement the [`Message`] trait.
 #[allow(unused_variables)]
-pub trait StreamHandler<T: 'static>: Actor {
+pub trait StreamHandler<M: 'static>: Actor {
     /// Method is called for every message received by this Actor.
     fn handle(
         &mut self,
         ctx: &mut Context<Self>,
-        msg: T,
+        msg: M,
     ) -> impl futures::Future<Output = ()> + Send;
 
     /// Method is called when stream get polled first time.
@@ -56,7 +56,7 @@ pub trait StreamHandler<T: 'static>: Actor {
 ///
 /// Roles communicate by exchanging messages.
 /// The requester can wait for a response.
-/// By [`Addr`] referring to the actors, the actors must provide an [`Handler<T>`] implementation for this message.
+/// By [`Addr`] referring to the actors, the actors must provide an [`Handler<M>`] implementation for this message.
 /// All messages are statically typed.
 #[allow(unused_variables)]
 pub trait Actor: Sized + Send + 'static {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -115,9 +115,9 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Send a message `msg` to the actor and wait for the return value.
-    pub async fn call<T: Message>(&self, msg: T) -> Result<T::Result>
+    pub async fn call<M: Message>(&self, msg: M) -> Result<M::Result>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
         let (repsonse_tx, response) = oneshot::channel();
         self.tx.send(ActorEvent::exec(move |actor, ctx| {
@@ -131,9 +131,9 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Send a message `msg` to the actor without waiting for the return value.
-    pub fn send<T: Message<Result = ()>>(&self, msg: T) -> Result<()>
+    pub fn send<M: Message<Result = ()>>(&self, msg: M) -> Result<()>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
         self.tx.send(ActorEvent::Exec(Box::new(move |actor, ctx| {
             Box::pin(Handler::handle(actor, ctx, msg))
@@ -141,10 +141,10 @@ impl<A: Actor> Addr<A> {
         Ok(())
     }
 
-    /// Create a [`Caller<T>`] for a specific message type
-    pub fn caller<T: Message>(&self) -> Caller<T>
+    /// Create a [`Caller<M>`] for a specific message type
+    pub fn caller<M: Message>(&self) -> Caller<M>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
         let weak_tx = Arc::downgrade(&self.tx);
 
@@ -161,7 +161,7 @@ impl<A: Actor> Addr<A> {
                     }))?;
 
                     Ok(response.await?)
-                }) as Pin<Box<dyn Future<Output = Result<T::Result>>>>
+                }) as Pin<Box<dyn Future<Output = Result<M::Result>>>>
             } else {
                 Box::pin(ready(Error::AlreadyStopped.into()))
             }
@@ -177,10 +177,10 @@ impl<A: Actor> Addr<A> {
         }
     }
 
-    /// Create a [`Sender<T>`] for a specific message type
-    pub fn sender<T: Message<Result = ()>>(&self) -> Sender<T>
+    /// Create a [`Sender<M>`] for a specific message type
+    pub fn sender<M: Message<Result = ()>>(&self) -> Sender<M>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
         let weak_tx = Arc::downgrade(&self.tx);
 

--- a/src/addr/caller.rs
+++ b/src/addr/caller.rs
@@ -7,38 +7,35 @@ use std::{
     pin::Pin,
 };
 
-pub(crate) trait CallerFn<T>: DynClone + Send + Sync + 'static
-where
-    T: Message,
-{
-    fn call(&self, msg: T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>>;
+pub(crate) trait CallerFn<M: Message>: DynClone + Send + Sync + 'static {
+    fn call(&self, msg: M) -> Pin<Box<dyn Future<Output = Result<M::Result>>>>;
 }
 
-impl<F, T> CallerFn<T> for F
+impl<F, M> CallerFn<M> for F
 where
-    F: Fn(T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>>,
+    F: Fn(M) -> Pin<Box<dyn Future<Output = Result<M::Result>>>>,
     F: 'static + Send + Sync + DynClone,
-    T: Message,
+    M: Message,
 {
-    fn call(&self, msg: T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>> {
+    fn call(&self, msg: M) -> Pin<Box<dyn Future<Output = Result<M::Result>>>> {
         self(msg)
     }
 }
 
 /// Caller of a specific message type
 ///
-/// Like [`Sender<T>`](`super::Sender<T>`), `Caller` has a weak reference to the recipient of the message type,
+/// Like [`Sender<M>`](`super::Sender<M>`), `Caller` has a weak reference to the recipient of the message type,
 /// and so will not prevent an actor from stopping if all [`Addr`](`crate::Addr`)'s have been dropped elsewhere.
 
-pub struct Caller<T: Message> {
+pub struct Caller<M: Message> {
     /// Id of the corresponding [`Actor<A>`](crate::Actor<A>)
     pub actor_id: ActorId,
-    pub(crate) caller_fn: Box<dyn CallerFn<T>>,
+    pub(crate) caller_fn: Box<dyn CallerFn<M>>,
     pub(crate) test_fn: Box<dyn TestFn>,
 }
 
-impl<T: Message> Caller<T> {
-    pub async fn call(&self, msg: T) -> Result<T::Result> {
+impl<M: Message> Caller<M> {
+    pub async fn call(&self, msg: M) -> Result<M::Result> {
         self.caller_fn.call(msg).await
     }
     pub fn can_upgrade(&self) -> bool {
@@ -46,19 +43,19 @@ impl<T: Message> Caller<T> {
     }
 }
 
-impl<T: Message<Result = ()>> PartialEq for Caller<T> {
+impl<M: Message<Result = ()>> PartialEq for Caller<M> {
     fn eq(&self, other: &Self) -> bool {
         self.actor_id == other.actor_id
     }
 }
 
-impl<T: Message<Result = ()>> Hash for Caller<T> {
+impl<M: Message<Result = ()>> Hash for Caller<M> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.actor_id.hash(state);
     }
 }
 
-impl<T: Message> Clone for Caller<T> {
+impl<M: Message> Clone for Caller<M> {
     fn clone(&self) -> Self {
         Self {
             actor_id: self.actor_id,

--- a/src/addr/sender.rs
+++ b/src/addr/sender.rs
@@ -3,40 +3,37 @@ use dyn_clone::DynClone;
 use super::{tester::TestFn, ActorId, Message, Result};
 use std::hash::{Hash, Hasher};
 
-pub(crate) trait SenderFn<T>: DynClone + 'static + Send + Sync
-where
-    T: Message,
-{
-    fn send(&self, msg: T) -> Result<()>;
+pub(crate) trait SenderFn<M: Message>: DynClone + 'static + Send + Sync {
+    fn send(&self, msg: M) -> Result<()>;
 }
 
-impl<F, T> SenderFn<T> for F
+impl<F, M> SenderFn<M> for F
 where
-    F: Fn(T) -> Result<()>,
+    F: Fn(M) -> Result<()>,
     F: 'static + Send + Sync + Clone,
-    T: Message,
+    M: Message,
 {
-    fn send(&self, msg: T) -> Result<()> {
+    fn send(&self, msg: M) -> Result<()> {
         self(msg)
     }
 }
 
 /// Sender of a specific message type
 ///
-/// Like [`Caller<T>`](`super::Caller<T>`), Sender has a weak reference to the recipient of the message type,
+/// Like [`Caller<M>`](`super::Caller<M>`), Sender has a weak reference to the recipient of the message type,
 /// and so will not prevent an actor from stopping if all [`Addr`](`crate::Addr`)'s have been dropped elsewhere.
 /// This allows it to be used in the `send_later` and `send_interval` actor functions,
 /// and not keep the actor alive indefinitely even after all references to it have been dropped (unless `ctx.stop()` is called from within)
 
-pub struct Sender<T: Message> {
+pub struct Sender<M: Message> {
     /// Id of the corresponding [`Actor<A>`](crate::Actor)
     pub actor_id: ActorId,
-    pub(crate) sender_fn: Box<dyn SenderFn<T>>,
+    pub(crate) sender_fn: Box<dyn SenderFn<M>>,
     pub(crate) test_fn: Box<dyn TestFn>,
 }
 
-impl<T: Message<Result = ()>> Sender<T> {
-    pub fn send(&self, msg: T) -> Result<()> {
+impl<M: Message<Result = ()>> Sender<M> {
+    pub fn send(&self, msg: M) -> Result<()> {
         self.sender_fn.send(msg)
     }
     pub fn can_upgrade(&self) -> bool {
@@ -44,13 +41,13 @@ impl<T: Message<Result = ()>> Sender<T> {
     }
 }
 
-impl<T: Message<Result = ()>> PartialEq for Sender<T> {
+impl<M: Message<Result = ()>> PartialEq for Sender<M> {
     fn eq(&self, other: &Self) -> bool {
         self.actor_id == other.actor_id
     }
 }
 
-impl<T: Message<Result = ()>> Hash for Sender<T> {
+impl<M: Message<Result = ()>> Hash for Sender<M> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.actor_id.hash(state);
     }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -4,12 +4,12 @@ use std::{any::Any, collections::HashMap, hash::BuildHasherDefault, marker::Phan
 
 type SubscriptionId = u64;
 
-pub(crate) struct Subscribe<T: Message<Result = ()>> {
+pub(crate) struct Subscribe<M: Message<Result = ()>> {
     pub(crate) id: SubscriptionId,
-    pub(crate) sender: Sender<T>,
+    pub(crate) sender: Sender<M>,
 }
 
-impl<T: Message<Result = ()>> Message for Subscribe<T> {
+impl<M: Message<Result = ()>> Message for Subscribe<M> {
     type Result = ();
 }
 
@@ -21,9 +21,9 @@ impl Message for Unsubscribe {
     type Result = ();
 }
 
-struct Publish<T: Message<Result = ()> + Clone>(T);
+struct Publish<M: Message<Result = ()> + Clone>(M);
 
-impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
+impl<M: Message<Result = ()> + Clone> Message for Publish<M> {
     type Result = ();
 }
 
@@ -79,12 +79,12 @@ impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
 ///     Ok(())
 /// }
 /// ```
-pub struct Broker<T: Message<Result = ()>> {
+pub struct Broker<M: Message<Result = ()>> {
     subscribes: HashMap<SubscriptionId, Box<dyn Any + Send>, BuildHasherDefault<FnvHasher>>,
-    mark: PhantomData<T>,
+    mark: PhantomData<M>,
 }
 
-impl<T: Message<Result = ()>> Default for Broker<T> {
+impl<M: Message<Result = ()>> Default for Broker<M> {
     fn default() -> Self {
         Self {
             subscribes: HashMap::default(),
@@ -93,35 +93,35 @@ impl<T: Message<Result = ()>> Default for Broker<T> {
     }
 }
 
-impl<T: Message<Result = ()>> Actor for Broker<T> {}
+impl<M: Message<Result = ()>> Actor for Broker<M> {}
 
-impl<T: Message<Result = ()>> Service for Broker<T> {}
+impl<M: Message<Result = ()>> Service for Broker<M> {}
 
-impl<T: Message<Result = ()>> Handler<Subscribe<T>> for Broker<T> {
-    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Subscribe<T>) {
+impl<M: Message<Result = ()>> Handler<Subscribe<M>> for Broker<M> {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Subscribe<M>) {
         self.subscribes.insert(msg.id, Box::new(msg.sender));
     }
 }
 
-impl<T: Message<Result = ()>> Handler<Unsubscribe> for Broker<T> {
+impl<M: Message<Result = ()>> Handler<Unsubscribe> for Broker<M> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Unsubscribe) {
         self.subscribes.remove(&msg.id);
     }
 }
 
-impl<T: Message<Result = ()> + Clone> Handler<Publish<T>> for Broker<T> {
-    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Publish<T>) {
+impl<M: Message<Result = ()> + Clone> Handler<Publish<M>> for Broker<M> {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Publish<M>) {
         for sender in self.subscribes.values_mut() {
-            if let Some(sender) = sender.downcast_mut::<Sender<T>>() {
+            if let Some(sender) = sender.downcast_mut::<Sender<M>>() {
                 sender.send(msg.0.clone()).ok();
             }
         }
     }
 }
 
-impl<T: Message<Result = ()> + Clone> Addr<Broker<T>> {
+impl<M: Message<Result = ()> + Clone> Addr<Broker<M>> {
     /// Publishes a message of the specified type.
-    pub fn publish(&mut self, msg: T) -> Result<()> {
+    pub fn publish(&mut self, msg: M) -> Result<()> {
         self.send(Publish(msg))
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -201,10 +201,9 @@ where
     ///
     /// We use `Sender` instead of `Addr` so that the interval doesn't keep reference to address and prevent the actor from being dropped and stopped
 
-    pub fn send_later<T>(&mut self, msg: T, after: Duration)
+    pub fn send_later<M: Message<Result = ()>>(&mut self, msg: M, after: Duration)
     where
-        A: Handler<T>,
-        T: Message<Result = ()>,
+        A: Handler<M>,
     {
         let sender = self.address().sender();
         let entry = self.intervals.vacant_entry();
@@ -222,11 +221,10 @@ where
 
     /// Sends the message  to self, at a specified fixed interval.
     /// The message is created each time using a closure `f`.
-    pub fn send_interval_with<T, F>(&mut self, f: F, dur: Duration)
+    pub fn send_interval_with<M: Message<Result = ()>, F>(&mut self, f: F, dur: Duration)
     where
-        A: Handler<T>,
-        F: Fn() -> T + Sync + Send + 'static,
-        T: Message<Result = ()>,
+        A: Handler<M>,
+        F: Fn() -> M + Sync + Send + 'static,
     {
         let sender = self.address().sender();
 
@@ -248,20 +246,20 @@ where
     }
 
     /// Sends the message `msg` to self, at a specified fixed interval.
-    pub fn send_interval<T>(&mut self, msg: T, dur: Duration)
+    pub fn send_interval<M>(&mut self, msg: M, dur: Duration)
     where
-        A: Handler<T>,
-        T: Message<Result = ()> + Clone + Sync,
+        A: Handler<M>,
+        M: Message<Result = ()> + Clone + Sync,
     {
         self.send_interval_with(move || msg.clone(), dur);
     }
 
     /// Subscribes to a message of a specified type.
-    pub async fn subscribe<T: Message<Result = ()>>(&self) -> Result<()>
+    pub async fn subscribe<M: Message<Result = ()>>(&self) -> Result<()>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
-        let broker = Broker::<T>::from_registry().await?;
+        let broker = Broker::<M>::from_registry().await?;
         let sender = self.address().sender();
         broker
             .send(Subscribe {
@@ -273,8 +271,8 @@ where
     }
 
     /// Unsubscribe to a message of a specified type.
-    pub async fn unsubscribe<T: Message<Result = ()>>(&self) -> Result<()> {
-        let broker = Broker::<T>::from_registry().await?;
+    pub async fn unsubscribe<M: Message<Result = ()>>(&self) -> Result<()> {
+        let broker = Broker::<M>::from_registry().await?;
         broker.send(Unsubscribe { id: self.actor_id })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<M> = std::result::Result<M, Error>;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -20,7 +20,7 @@ pub enum Error {
     Canceled(#[from] futures::channel::oneshot::Canceled),
 }
 
-impl<T> From<Error> for Result<T> {
+impl<M> From<Error> for Result<M> {
     fn from(val: Error) -> Self {
         Err(val)
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,9 +14,9 @@ use futures::Future;
 pub use tokio::{task::spawn, time::sleep, time::timeout};
 
 #[cfg(feature = "runtime-tokio")]
-pub fn block_on<F, T>(future: F) -> T
+pub fn block_on<F, M>(future: F) -> M
 where
-    F: Future<Output = T>,
+    F: Future<Output = M>,
 {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(future)

--- a/src/weak_addr.rs
+++ b/src/weak_addr.rs
@@ -48,9 +48,9 @@ impl<A> WeakAddr<A> {
     }
 
     /// Try to upgrade to [`Addr`] and call [`Addr::send`]
-    pub fn upgrade_send<T: Message<Result = ()>>(&self, msg: T) -> Result<()>
+    pub fn upgrade_send<M: Message<Result = ()>>(&self, msg: M) -> Result<()>
     where
-        A: Handler<T>,
+        A: Handler<M>,
     {
         if let Some(addr) = self.upgrade() {
             addr.send(msg)


### PR DESCRIPTION
instead of `T`